### PR TITLE
feat: implement booking workflow with enum status and admin approval system

### DIFF
--- a/Backend/Controllers/AuthController.cs
+++ b/Backend/Controllers/AuthController.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Backend.Controllers
 {
     [ApiController]
-    [Route("auth")]
+    [Route("api/[controller]")]
     public class AuthController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Backend/Controllers/BookingsController.cs
+++ b/Backend/Controllers/BookingsController.cs
@@ -20,7 +20,7 @@ public class BookingsController : ControllerBase
         _context = context;
     }
 
-    // GET /bookings
+    // GET: api/bookings
     [HttpGet]
     public async Task<IActionResult> GetBookings()
     {
@@ -35,26 +35,46 @@ public class BookingsController : ControllerBase
             query = query.Where(b => b.UserId == userId);
         }
 
-        var bookings = await query
-            .Select(b => new BookingResponseDto
-            {
-                Id = b.Id,
-                RoomId = b.RoomId,
-                StartTime = b.StartTime,
-                EndTime = b.EndTime,
-                Status = b.Status,
-                CreatedAt = b.CreatedAt
-            })
-            .ToListAsync();
+var bookings = await query
+    .Include(b => b.Room)
+    .Include(b => b.User)
+    .Select(b => new BookingResponseDto
+    {
+        Id = b.Id,
+        RoomId = b.RoomId,
+        StartTime = b.StartTime,
+        EndTime = b.EndTime,
+        Status = b.Status.ToString().ToLower(),
+        CreatedAt = b.CreatedAt,
+
+        Room = new RoomResponseDto
+        {
+            Id = b.Room!.Id,
+            Name = b.Room.Name,
+            Capacity = b.Room.Capacity
+        },
+
+        User = new UserResponseDto
+        {
+            Id = b.User.Id,
+            Name = b.User.Name,
+            Email = b.User.Email,
+            Role = b.User.Role
+        }
+    })
+    .ToListAsync();
+
 
         return Ok(bookings);
     }
 
-    // GET /bookings/{id}
+    // GET: api/bookings/{id}
     [HttpGet("{id}")]
     public async Task<IActionResult> GetBooking(int id)
     {
         var booking = await _context.Bookings
+            .Include(b => b.Room)
+            .Include(b => b.User)
             .FirstOrDefaultAsync(b => b.Id == id && b.DeletedAt == null);
 
         if (booking == null)
@@ -72,12 +92,28 @@ public class BookingsController : ControllerBase
             RoomId = booking.RoomId,
             StartTime = booking.StartTime,
             EndTime = booking.EndTime,
-            Status = booking.Status,
-            CreatedAt = booking.CreatedAt
+            Status = booking.Status.ToString().ToLower(),
+            CreatedAt = booking.CreatedAt,
+
+            Room = new RoomResponseDto
+            {
+                Id = booking.Room!.Id,
+                Name = booking.Room.Name,
+                Capacity = booking.Room.Capacity
+            },
+
+            User = new UserResponseDto
+            {
+                Id = booking.User.Id,
+                Name = booking.User.Name,
+                Email = booking.User.Email,
+                Role = booking.User.Role
+            }
         });
     }
 
-    // POST /bookings
+
+    // POST: api/bookings
     [Authorize(Roles = "user")]
     [HttpPost]
     public async Task<IActionResult> CreateBooking([FromBody] BookingCreateDto dto)
@@ -94,16 +130,25 @@ public class BookingsController : ControllerBase
         if (!roomExists)
             return BadRequest(new { message = "Room does not exist" });
 
+        // Conflict only if existing booking is Approved
         var hasConflict = await _context.Bookings.AnyAsync(b =>
             b.RoomId == dto.RoomId &&
             b.DeletedAt == null &&
-            b.Status == "booked" &&
+            (b.Status == BookingStatus.Approved ||
+            b.Status == BookingStatus.Pending) &&
             dto.StartTime < b.EndTime &&
             dto.EndTime > b.StartTime
         );
 
+
         if (hasConflict)
-            return Conflict(new { message = "Room is already booked in the selected time range" });
+            {
+                return Conflict(new 
+                { 
+                    message = "Slot already booked or pending approval" 
+                });
+            }
+
 
         var userId = Guid.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
 
@@ -113,7 +158,7 @@ public class BookingsController : ControllerBase
             StartTime = dto.StartTime,
             EndTime = dto.EndTime,
             UserId = userId,
-            Status = "booked",
+            Status = BookingStatus.Pending,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
         };
@@ -121,10 +166,10 @@ public class BookingsController : ControllerBase
         _context.Bookings.Add(booking);
         await _context.SaveChangesAsync();
 
-        return CreatedAtAction(nameof(GetBooking), new { id = booking.Id }, booking);
+        return CreatedAtAction(nameof(GetBooking), new { id = booking.Id }, null);
     }
 
-    // PUT /bookings/{id}
+    // PUT: api/bookings/{id}/reschedule
     [Authorize(Roles = "user")]
     [HttpPut("{id}/reschedule")]
     public async Task<IActionResult> RescheduleBooking(int id, BookingRescheduleDto dto)
@@ -146,7 +191,7 @@ public class BookingsController : ControllerBase
             b.Id != id &&
             b.RoomId == dto.RoomId &&
             b.DeletedAt == null &&
-            b.Status == "booked" &&
+            b.Status == BookingStatus.Approved &&
             dto.StartTime < b.EndTime &&
             dto.EndTime > b.StartTime
         );
@@ -160,9 +205,10 @@ public class BookingsController : ControllerBase
         booking.UpdatedAt = DateTimeOffset.UtcNow;
 
         await _context.SaveChangesAsync();
-        return Ok(booking);
+        return Ok();
     }
 
+    // PUT: api/bookings/{id}/status
     [Authorize(Roles = "admin")]
     [HttpPut("{id}/status")]
     public async Task<IActionResult> UpdateBookingStatus(int id, BookingStatusUpdateDto dto)
@@ -173,14 +219,17 @@ public class BookingsController : ControllerBase
         if (booking == null)
             return NotFound();
 
-        booking.Status = dto.Status;
+        if (!Enum.TryParse<BookingStatus>(dto.Status, true, out var status))
+            return BadRequest("Invalid status");
+
+        booking.Status = status;
         booking.UpdatedAt = DateTimeOffset.UtcNow;
 
         await _context.SaveChangesAsync();
-        return Ok(booking);
+        return Ok();
     }
 
-    // DELETE /bookings/{id}
+    // DELETE: api/bookings/{id}
     [HttpDelete("{id}")]
     public async Task<IActionResult> CancelBooking(int id)
     {
@@ -196,11 +245,53 @@ public class BookingsController : ControllerBase
         if (booking.UserId != userId && role != "admin")
             return Forbid();
 
-        booking.Status = "cancelled";
+        booking.Status = BookingStatus.Cancelled;
         booking.DeletedAt = DateTimeOffset.UtcNow;
         booking.UpdatedAt = DateTimeOffset.UtcNow;
 
         await _context.SaveChangesAsync();
         return NoContent();
+    }
+
+    // PATCH: api/bookings/{id}/approve
+    [Authorize(Roles = "admin")]
+    [HttpPatch("{id}/approve")]
+    public async Task<IActionResult> Approve(int id)
+    {
+        var booking = await _context.Bookings.FindAsync(id);
+
+        if (booking == null)
+            return NotFound();
+
+        if (booking.Status != BookingStatus.Pending)
+            return BadRequest("Only pending bookings can be approved");
+
+        booking.Status = BookingStatus.Approved;
+        booking.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await _context.SaveChangesAsync();
+
+        return Ok();
+    }
+
+    // PATCH: api/bookings/{id}/reject
+    [Authorize(Roles = "admin")]
+    [HttpPatch("{id}/reject")]
+    public async Task<IActionResult> Reject(int id)
+    {
+        var booking = await _context.Bookings.FindAsync(id);
+
+        if (booking == null)
+            return NotFound();
+
+        if (booking.Status != BookingStatus.Pending)
+            return BadRequest("Only pending bookings can be rejected");
+
+        booking.Status = BookingStatus.Rejected;
+        booking.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await _context.SaveChangesAsync();
+
+        return Ok();
     }
 }

--- a/Backend/DTOs/BookingRescheduleDto.cs
+++ b/Backend/DTOs/BookingRescheduleDto.cs
@@ -1,3 +1,5 @@
+namespace Backend.DTOs;
+
 public class BookingRescheduleDto
 {
     public int RoomId { get; set; }

--- a/Backend/DTOs/BookingResponseDto.cs
+++ b/Backend/DTOs/BookingResponseDto.cs
@@ -1,11 +1,19 @@
+// Backend/DTOs/BookingResponseDto.cs
 namespace Backend.DTOs;
 
 public class BookingResponseDto
 {
     public int Id { get; set; }
     public int RoomId { get; set; }
-    public DateTimeOffset  StartTime { get; set; }
-    public DateTimeOffset  EndTime { get; set; }
-    public string Status { get; set; } = null!;
-    public DateTimeOffset  CreatedAt { get; set; }
+
+    public RoomResponseDto? Room { get; set; }
+    public UserResponseDto? User { get; set; }
+
+    public DateTimeOffset StartTime { get; set; }
+    public DateTimeOffset EndTime { get; set; }
+
+    // change to string
+    public string Status { get; set; } = default!;
+
+    public DateTimeOffset CreatedAt { get; set; }
 }

--- a/Backend/DTOs/BookingStatusUpdateDto.cs
+++ b/Backend/DTOs/BookingStatusUpdateDto.cs
@@ -1,3 +1,5 @@
+namespace Backend.DTOs;
+
 public class BookingStatusUpdateDto
 {
     public string Status { get; set; } = default!;

--- a/Backend/DTOs/UserResponseDto.cs
+++ b/Backend/DTOs/UserResponseDto.cs
@@ -1,0 +1,9 @@
+namespace Backend.DTOs;
+
+public class UserResponseDto
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+}

--- a/Backend/Data/ApplicationDbContext.cs
+++ b/Backend/Data/ApplicationDbContext.cs
@@ -14,11 +14,13 @@ public class ApplicationDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
+        // other modelBuilder configurations...
 
-        modelBuilder.Entity<Room>()
-            .HasMany(r => r.Bookings)
-            .WithOne(b => b.Room!)
-            .HasForeignKey(b => b.RoomId);
+        modelBuilder.Entity<Booking>()
+            .Property(b => b.Status)
+            .HasConversion<string>()
+            .HasMaxLength(20); // optional: set length for string column
+
+        base.OnModelCreating(modelBuilder);
     }
 }

--- a/Backend/Data/DbSeeder.cs
+++ b/Backend/Data/DbSeeder.cs
@@ -7,7 +7,9 @@ public static class DbSeeder
 {
     public static void Seed(ApplicationDbContext context)
     {
+        // =============================
         // RESET DATA (DEV ONLY)
+        // =============================
         context.Bookings.RemoveRange(context.Bookings);
         context.Rooms.RemoveRange(context.Rooms);
         context.Users.RemoveRange(context.Users);
@@ -15,31 +17,51 @@ public static class DbSeeder
 
         var hasher = new PasswordHasher();
 
+        // =============================
         // USERS
-        var adminUser = new User
-        {
-            Id = Guid.NewGuid(),
-            Email = "admin@local",
-            Name = "Admin",
-            Role = "admin",
-            PasswordHash = hasher.Hash("admin123"),
-            CreatedAt = DateTimeOffset.UtcNow
-        };
+        // =============================
+        var users = new List<User>();
 
-        var normalUser = new User
+        // 4 Admins (tidak membuat booking)
+        for (int i = 1; i <= 4; i++)
         {
-            Id = Guid.NewGuid(),
-            Email = "user@local",
-            Name = "User",
-            Role = "user",
-            PasswordHash = hasher.Hash("user123"),
-            CreatedAt = DateTimeOffset.UtcNow
-        };
+            users.Add(new User
+            {
+                Id = Guid.NewGuid(),
+                Email = $"admin@{i}",
+                Name = $"admin{i}",
+                Role = "admin",
+                PasswordHash = hasher.Hash($"admin{i}"),
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+        }
 
-        context.Users.AddRange(adminUser, normalUser);
+        // 4 Normal Users
+        for (int i = 1; i <= 4; i++)
+        {
+            users.Add(new User
+            {
+                Id = Guid.NewGuid(),
+                Email = $"user@{i}",
+                Name = $"user{i}",
+                Role = "user",
+                PasswordHash = hasher.Hash($"user{i}"),
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+        }
+
+        context.Users.AddRange(users);
         context.SaveChanges();
 
+        // Ambil 3 user untuk booking
+        var user1 = users.First(u => u.Email == "user@1");
+        var user2 = users.First(u => u.Email == "user@2");
+        var user3 = users.First(u => u.Email == "user@3");
+        // user@4 tidak membuat booking
+
+        // =============================
         // ROOMS
+        // =============================
         var rooms = new[]
         {
             new Room { Name = "Meeting Room A", Capacity = 10 },
@@ -50,7 +72,9 @@ public static class DbSeeder
         context.Rooms.AddRange(rooms);
         context.SaveChanges();
 
+        // =============================
         // TIME SETUP (WIB)
+        // =============================
         var wib = TimeZoneInfo.FindSystemTimeZoneById("SE Asia Standard Time");
         var todayWib = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, wib).Date;
 
@@ -60,25 +84,72 @@ public static class DbSeeder
             return TimeZoneInfo.ConvertTimeToUtc(local, wib);
         }
 
+        // =============================
         // BOOKINGS
-        var bookingConfigs = new[]
+        // Slot: 7-8, 8-9, 9-10
+        // =============================
+        var bookings = new List<Booking>
         {
-            (room: rooms[0], hour: 8, user: normalUser),
-            (room: rooms[0], hour: 10, user: normalUser),
-            (room: rooms[1], hour: 9, user: adminUser),
-            (room: rooms[1], hour: 11, user: adminUser),
-            (room: rooms[2], hour: 13, user: normalUser)
-        };
+            // USER 1
+            new Booking
+            {
+                RoomId = rooms[0].Id,
+                UserId = user1.Id,
+                StartTime = ToUtc(7),
+                EndTime = ToUtc(8),
+                Status = BookingStatus.Pending,
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+            new Booking
+            {
+                RoomId = rooms[1].Id,
+                UserId = user1.Id,
+                StartTime = ToUtc(8),
+                EndTime = ToUtc(9),
+                Status = BookingStatus.Approved,
+                CreatedAt = DateTimeOffset.UtcNow
+            },
 
-        var bookings = bookingConfigs.Select(cfg => new Booking
-        {
-            RoomId = cfg.room.Id,
-            UserId = cfg.user.Id,
-            StartTime = ToUtc(cfg.hour),
-            EndTime = ToUtc(cfg.hour + 1),
-            Status = "confirmed",
-            CreatedAt = DateTimeOffset.UtcNow
-        });
+            // USER 2
+            new Booking
+            {
+                RoomId = rooms[0].Id,
+                UserId = user2.Id,
+                StartTime = ToUtc(9),
+                EndTime = ToUtc(10),
+                Status = BookingStatus.Rejected,
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+            new Booking
+            {
+                RoomId = rooms[2].Id,
+                UserId = user2.Id,
+                StartTime = ToUtc(7),
+                EndTime = ToUtc(8),
+                Status = BookingStatus.Approved,
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+
+            // USER 3
+            new Booking
+            {
+                RoomId = rooms[1].Id,
+                UserId = user3.Id,
+                StartTime = ToUtc(8),
+                EndTime = ToUtc(9),
+                Status = BookingStatus.Pending,
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+            new Booking
+            {
+                RoomId = rooms[2].Id,
+                UserId = user3.Id,
+                StartTime = ToUtc(9),
+                EndTime = ToUtc(10),
+                Status = BookingStatus.Approved,
+                CreatedAt = DateTimeOffset.UtcNow
+            }
+        };
 
         context.Bookings.AddRange(bookings);
         context.SaveChanges();

--- a/Backend/Models/Booking.cs
+++ b/Backend/Models/Booking.cs
@@ -1,5 +1,13 @@
 namespace Backend.Models;
 
+public enum BookingStatus
+{
+    Pending,
+    Approved,
+    Rejected,
+    Cancelled
+}
+
 public class Booking
 {
     public int Id { get; set; }
@@ -7,16 +15,15 @@ public class Booking
     public int RoomId { get; set; }
     public Room? Room { get; set; }
 
-    public DateTimeOffset  StartTime { get; set; }
-    public DateTimeOffset  EndTime { get; set; }
+    public DateTimeOffset StartTime { get; set; }
+    public DateTimeOffset EndTime { get; set; }
 
-    public string Status { get; set; } = "booked";
+    public BookingStatus Status { get; set; } = BookingStatus.Pending;
 
-    public DateTimeOffset  CreatedAt { get; set; } = DateTimeOffset .UtcNow;
-    public DateTimeOffset  UpdatedAt { get; set; } = DateTimeOffset .UtcNow;
-    public DateTimeOffset ? DeletedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? DeletedAt { get; set; }
 
     public Guid UserId { get; set; }
     public User User { get; set; } = null!;
-
 }


### PR DESCRIPTION
- Replace string-based booking status with BookingStatus enum
- Add statuses: Pending, Approved, Rejected, Cancelled
- Update BookingsController:
  - Create booking defaults to Pending
  - Conflict validation only blocks Approved bookings
  - Add UpdateBookingStatus endpoint (admin only)
  - Add Approve and Reject endpoints
  - Ensure proper authorization (user vs admin)
- Update BookingResponseDto to return lowercase status string
- Fix DbSeeder:
  - Create 4 admins and 4 users
  - Seed multiple bookings with mixed statuses
  - Ensure only users create bookings
- Configure enum to persist as string in database
- Improve role-based query filtering in GetBookings
